### PR TITLE
dialects: (stablehlo) Add 1-bit integers to `IntType`s

### DIFF
--- a/src/xdsl_jax/dialects/stablehlo/types.py
+++ b/src/xdsl_jax/dialects/stablehlo/types.py
@@ -33,7 +33,7 @@ from xdsl.irdl import (
 from .attributes import TokenType
 
 SIntType: TypeAlias = IntegerType[
-    Literal[2, 4, 8, 16, 32, 64],
+    Literal[1, 2, 4, 8, 16, 32, 64],
     Literal[Signedness.SIGNLESS],
 ]
 # NOTE: IntegerType is defined in the StableHLO spec as:
@@ -41,7 +41,7 @@ SIntType: TypeAlias = IntegerType[
 # but the MLIR implementation is using signless integers instead of signed,
 # and there is a TODO to fix it.
 IntType: TypeAlias = IntegerType[
-    Literal[2, 4, 8, 16, 32, 64],
+    Literal[1, 2, 4, 8, 16, 32, 64],
     Literal[Signedness.UNSIGNED, Signedness.SIGNLESS],
 ]
 Float32Or64Type: TypeAlias = Float32Type | Float64Type

--- a/tests/filecheck/dialects/stablehlo/ops_elementwise_unary.mlir
+++ b/tests/filecheck/dialects/stablehlo/ops_elementwise_unary.mlir
@@ -35,6 +35,10 @@
 // CHECK-GENERIC: %[[CONVERT:.*]] = "stablehlo.convert"(%[[T0]]) : (tensor<i32>) -> tensor<f32>
 %convert = stablehlo.convert %t0 : (tensor<i32>) -> tensor<f32>
 
+// CHECK: %[[CONVERT:.*]] = stablehlo.convert %[[T0]] : (tensor<i32>) -> tensor<i1>
+// CHECK-GENERIC: %[[CONVERT:.*]] = "stablehlo.convert"(%[[T0]]) : (tensor<i32>) -> tensor<i1>
+%convert_i1 = stablehlo.convert %t0 : (tensor<i32>) -> tensor<i1>
+
 // CHECK: %[[COSINE:.*]] = stablehlo.cosine %[[TF32]] : tensor<f32>
 // CHECK-GENERIC: %[[COSINE:.*]] = "stablehlo.cosine"(%[[TF32]]) : (tensor<f32>) -> tensor<f32>
 %cosine = stablehlo.cosine %tf32 : tensor<f32>


### PR DESCRIPTION
In mlir, `i1` is a legal integer type. For example, the following
```
func.func @aloha(%arg0: tensor<1xi1>) {
    %0 = stablehlo.convert %arg0 : tensor<1xi1>
    return
}
```

is a valid mlir program. 

However, the xdsl-jax implementation is missing `i1` integers in the `IntType`s, causing the above to crash during parsing. See https://github.com/xdslproject/xdsl/issues/5991

We add 1-bit integers to the integer types. 